### PR TITLE
[RO-3117] Change the use of rsync_opts to an array

### DIFF
--- a/apt/aptly-all.yml
+++ b/apt/aptly-all.yml
@@ -32,7 +32,11 @@
         dest: "{{ artifacts_aptrepos_dest_folder | dirname }}"
         mode: pull
         delete: yes
-        rsync_opts: "--quiet --stats --log-file='/var/log/rpc-repo.log' --chown={{ aptly_user }}:www-data"
+        rsync_opts:
+          - "--quiet"
+          - "--stats"
+          - "--log-file='/var/log/rpc-repo.log'"
+          - "--chown={{ webservice_owner }}:www-data"
       register: synchronize
       until: synchronize | success
       retries: 5
@@ -105,7 +109,11 @@
         dest: "{{ artifacts_aptrepos_dest_folder | dirname }}"
         mode: push
         delete: yes
-        rsync_opts: "--quiet --stats --log-file='/var/log/rpc-repo.log' --chown={{ webservice_owner }}:www-data"
+        rsync_opts:
+          - "--quiet"
+          - "--stats"
+          - "--log-file='/var/log/rpc-repo.log'"
+          - "--chown={{ webservice_owner }}:www-data"
       register: synchronize
       until: synchronize | success
       retries: 5


### PR DESCRIPTION
The Ansible synconize module expects the rsync_opts field to be an
array. This change modifies the string we had to an array so that it's
using the expected syntax.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>